### PR TITLE
Fix fruits logic to render out fruit from each created instances

### DIFF
--- a/js/fruits.js
+++ b/js/fruits.js
@@ -6,7 +6,9 @@ class Fruit {
       "./images/lemon.png",
       "./images/pineapple.png",
     ];
-    this.fruitNo = Math.round(Math.random() * (this.fruitImgs.length - 1));
+    let fruitNo = Math.round(Math.random() * (this.fruitImgs.length - 1));
+
+    this.image.src = this.fruitImgs[fruitNo];
 
     this.position = [
       [{ x: 430, y: 250 }],
@@ -35,41 +37,35 @@ class Fruit {
     this.height = 48;
     this.imageHeight = 64;
     this.imageWidth = 270;
+    this.isSeen = true;
   }
-  update(ctx) {
-    for (let index = 0; index < this.position[game.level]?.length; index++) {
-      this.image.src = this.fruitImgs[this.fruitNo];
+  update(ctx, x, y) {
+    if (this.isSeen) {
       ctx.drawImage(
         this.image,
         0,
         0,
         this.imageWidth,
         this.imageHeight,
-        this.position[game.level][index].x,
-        this.position[game.level][index].y,
+        x,
+        y,
         this.imageWidth,
         this.imageHeight
       );
+      this.fruitCollision(game.monkey, this, x, y);
     }
-    this.fruitCollision(game.monkey, this);
   }
 
-  fruitCollision(rect1, rect2) {
-    for (let index = 0; index < this.position[game.level].length; index++) {
-      let fruitCollision =
-        rect1.position[game.level].x <
-          rect2.position[game.level][index].x + rect2.width &&
-        rect1.position[game.level].x + rect1.width >
-          rect2.position[game.level][index].x &&
-        rect1.position[game.level].y <
-          rect2.position[game.level][index].y + rect2.height &&
-        rect1.position[game.level].y + rect1.height >
-          rect2.position[game.level][index].y;
-      if (fruitCollision) {
-        this.position[game.level].splice(index, 1);
-        score += fruitsPoint;
-        game.sound.eat.play();
-      }
+  fruitCollision(monkey, rect2, x, y) {
+    let fruitCollision =
+      monkey.position[game.level].x < x + rect2.width &&
+      monkey.position[game.level].x + monkey.width > x &&
+      monkey.position[game.level].y < y + rect2.height &&
+      monkey.position[game.level].y + monkey.height > y;
+    if (fruitCollision) {
+      this.isSeen = false;
+      score += fruitsPoint;
+      game.sound.eat.play();
     }
   }
 }

--- a/js/level.js
+++ b/js/level.js
@@ -1,26 +1,51 @@
+let f1 = new Fruit();
+let f2 = new Fruit();
+let f3 = new Fruit();
+let f4 = new Fruit();
+let f5 = new Fruit();
+let f6 = new Fruit();
+let f7 = new Fruit();
+let f8 = new Fruit();
+let f9 = new Fruit();
+let f10 = new Fruit();
+let f11 = new Fruit();
+let f12 = new Fruit();
 class Level {
-  constructor() {}
   update(ctx) {
     canvas.style.display = "block";
     game.gameClock += 1;
     game.background.update(ctx);
-    game.fruit.update(ctx);
     game.checkBorderCollision();
+
+    if (game.level === 0) {
+      f1.update(ctx, 430, 250);
+    }
     if (game.level === 1) {
+      f2.update(ctx, 550, 300);
+      f3.update(ctx, 350, 300);
       game.cliffLeft.update(ctx);
       game.cliffRight.update(ctx);
     }
     if (game.level === 2) {
+      f4.update(ctx, 880, 150);
+      f5.update(ctx, 670, 350);
+      f6.update(ctx, 350, 350);
       game.ropeReversed.update(ctx);
       game.headOnSpike.update(ctx);
       game.coconutTree.update(ctx);
     }
     if (game.level === 3) {
+      f7.update(ctx, 500, 60);
+      f8.update(ctx, 850, 250);
+      f9.update(ctx, 900, 450);
       game.bigCliff.update(ctx);
       game.rope.update(ctx);
       game.coconutTree.update(ctx);
     }
     if (game.level === 4) {
+      f10.update(ctx, 250, 390);
+      f11.update(ctx, 580, 360);
+      f12.update(ctx, 650, 220);
       game.coconutTree.update(ctx);
       game.headOnSpikeReverse.update(ctx);
       game.rock.update(ctx);


### PR DESCRIPTION
## Descriptions 
- Fix fruits logic to render out one fruit from each created instance
- Random Fruits can be generated in each level having the same no of fruit 

## Reason for change 
- Previously fruits were rendered out by looping on the update method in the fruit class. 
- The code was too messy and hard to understand. 
-  By doing these changes we can easily help create a fruit in Level Builder 